### PR TITLE
After removing clone in AwtMouseInput.java

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/input/awt/AwtMouseInput.java
+++ b/jme3-desktop/src/main/java/com/jme3/input/awt/AwtMouseInput.java
@@ -234,11 +234,10 @@ public class AwtMouseInput implements MouseInput, MouseListener, MouseWheelListe
 //        listener.onMouseButtonEvent(evt);
     }
 
-    @Override
-    public void mousePressed(MouseEvent awtEvt) {
-        // Must flip Y!
+    // New helper method to handle mouse button events
+    private void handleMouseButtonEvent(MouseEvent awtEvt, boolean isPressed) {
         int y = component.getHeight() - awtEvt.getY();
-        MouseButtonEvent evt = new MouseButtonEvent(getJMEButtonIndex(awtEvt), true, awtEvt.getX(), y);
+        MouseButtonEvent evt = new MouseButtonEvent(getJMEButtonIndex(awtEvt), isPressed, awtEvt.getX(), y);
         evt.setTime(awtEvt.getWhen());
         synchronized (eventQueue) {
             eventQueue.add(evt);
@@ -246,13 +245,13 @@ public class AwtMouseInput implements MouseInput, MouseListener, MouseWheelListe
     }
 
     @Override
+    public void mousePressed(MouseEvent awtEvt) {
+        handleMouseButtonEvent(awtEvt, true);
+    }
+
+    @Override
     public void mouseReleased(MouseEvent awtEvt) {
-        int y = component.getHeight() - awtEvt.getY();
-        MouseButtonEvent evt = new MouseButtonEvent(getJMEButtonIndex(awtEvt), false, awtEvt.getX(), y);
-        evt.setTime(awtEvt.getWhen());
-        synchronized (eventQueue) {
-            eventQueue.add(evt);
-        }
+        handleMouseButtonEvent(awtEvt, false);
     }
 
     @Override


### PR DESCRIPTION
There's a duplication in AwtMouseInput.java which involves the same block of code being repeated in two places: in the mousePressed and mouseReleased methods.

Location of the clones
Starting at line 241 of jmonkeyengineFall2024-master\jme3-desktop\src\main\java\com\jme3\input\awt\AwtMouseInput.java
Starting at line 251 of jmonkeyengineFall2024-master\jme3-desktop\src\main\java\com\jme3\input\awt\AwtMouseInput.java

Both methods (the mousePressed and mouseReleased methods) are handling mouse events in a similar way, so we refactored this into a helper method to remove the duplication.