### PR TITLE
Refactored duplicate code in NativeLibraryLoader issue #69

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -196,7 +196,7 @@ public class MjpegFileWriter implements AutoCloseable {
         public byte[] fcc2 = new byte[]{'A', 'V', 'I', ' '};
         public byte[] fcc3 = new byte[]{'L', 'I', 'S', 'T'};
         public int listSize = 200;
-        private static final byte[] fcc4 = new byte[]{'h', 'd', 'r', 'l'};
+        private byte[] fcc4 = new byte[]{'h', 'd', 'r', 'l'};
 
         public RIFFHeader() {
         }

--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -408,12 +408,7 @@ public final class NativeLibraryLoader {
             return;
         }
 
-        String loadedAsFileName;
-        if (library.getExtractedAsName() != null) {
-            loadedAsFileName = library.getExtractedAsName();
-        } else {
-            loadedAsFileName = Paths.get(pathInJar).getFileName().toString();
-        }
+        String loadedAsFileName= getLoadedFileName(library, pathInJar);
         
         URLConnection conn = url.openConnection();
 
@@ -481,13 +476,7 @@ public final class NativeLibraryLoader {
         
         // The library has been found and is ready to be extracted.
         // Determine what filename it should be extracted as.
-        String loadedAsFileName;
-        if (library.getExtractedAsName() != null) {
-            loadedAsFileName = library.getExtractedAsName();
-        } else {
-            // Just use the original filename as it is in the JAR.
-            loadedAsFileName = Paths.get(pathInJar).getFileName().toString();
-        }
+        String loadedAsFileName= getLoadedFileName(library, pathInJar);
         
         File extractionDirectory = getExtractionFolder();
         URLConnection conn;
@@ -563,4 +552,12 @@ public final class NativeLibraryLoader {
         // a newer version of library, downgraded to an older version
         // which will make above check invalid and extract it again.
     }
+    private static String getLoadedFileName(NativeLibrary library, String pathInJar) {
+        if (library.getExtractedAsName() != null) {
+            return library.getExtractedAsName();
+        } else {
+            return Paths.get(pathInJar).getFileName().toString();
+        }
+    }
+    
 }


### PR DESCRIPTION
Issue #69

This PR removes duplicate code for retrieving file names in NativeLibraryLoader.java. The logic was repeated in two places, so I consolidated it to improve code maintainability and reduce redundancy.