### PR TITLE
Update NativeLibraryLoader to address issue #132

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -467,9 +467,11 @@ public final class NativeLibraryLoader {
                         "The required native library '" + library.getName() + "'"
                                 + " was not found in the classpath via '" + pathInJar);
             } else if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "The optional native library ''{0}''" +
-                                " was not found in the classpath via ''{1}''.",
-                        new Object[]{library.getName(), pathInJar});
+                logger.log(Level.FINE,
+                        "The optional native library ''{0}''"
+                                + " was not found in the classpath via ''{1}''.",
+                        new Object[] { library.getName().replaceAll("[\\r\\n]", ""),
+                                pathInJar.replaceAll("[\\r\\n]", "") });
             }
             return;
         }


### PR DESCRIPTION
Issue #132

Fixed CRLF Injection vulnerability (CWE-93) by sanitizing user input before logging, removing newline characters (\r\n). This prevents potential log corruption or malicious code injection, addressing the issue flagged as "Troubling" by SpotBugs.