### PR TITLE
Fix Path Traversal Vulnerability #142

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,9 @@ buildscript {
         classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.18"
     }
 }
-
+plugins {
+  id "org.sonarqube" version "5.1.0.4882"
+}
 allprojects {
     repositories {
         mavenCentral()

--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -43,6 +43,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import com.jme3.util.res.Resources;
 
@@ -319,15 +323,28 @@ public final class NativeLibraryLoader {
     }
     
     public static void extractNativeLibraries(Platform platform, File targetDir) throws IOException {
-        for (Map.Entry<NativeLibrary.Key, NativeLibrary> lib : nativeLibraryMap.entrySet()) {
-            if (lib.getValue().getPlatform() == platform) {
-                if (!targetDir.exists()) {
-                    targetDir.mkdirs();
-                }
-                extractNativeLibrary(platform, lib.getValue().getName(), targetDir);
+    // Ensure the target directory is canonicalized and sanitized
+    Path canonicalTargetDir = targetDir.toPath().toRealPath(); // Resolves any symlinks or relative paths
+
+    for (Map.Entry<NativeLibrary.Key, NativeLibrary> lib : nativeLibraryMap.entrySet()) {
+        if (lib.getValue().getPlatform() == platform) {
+            // Validate the directory before proceeding
+            Path entryPath = new File(targetDir, lib.getValue().getName()).toPath().normalize();
+
+            // Ensure the entryPath is within the canonicalTargetDir
+            if (!entryPath.startsWith(canonicalTargetDir)) {
+                throw new IOException("Path traversal detected: " + entryPath);
             }
+
+            if (!targetDir.exists()) {
+                targetDir.mkdirs();
+            }
+
+            extractNativeLibrary(platform, lib.getValue().getName(), targetDir);
         }
     }
+}
+
     
     /**
      * Removes platform-specific portions of a library file name so


### PR DESCRIPTION
Unsanitized input from a command-line argument is used to construct a file path, which is evaluated with the exists() method. This creates a potential Path Traversal vulnerability (CWE-23), allowing attackers to bypass application logic and access restricted files or directories. Proper input sanitization and path validation are required to resolve this issue. Fixes rilling/jmonkeyengineFall2024#142