### PR TITLE
Fixed Denial of Service (DoS) vulnerability in ShaderGenerator.java

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shader/ShaderGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/shader/ShaderGenerator.java
@@ -236,7 +236,7 @@ public abstract class ShaderGenerator {
     protected void appendNodeDeclarationAndMain(String loadedSource, StringBuilder sourceDeclaration, StringBuilder source, ShaderNode shaderNode, ShaderGenerationInfo info, String shaderPath) {
         if (loadedSource.length() > 1) {
             loadedSource = loadedSource.substring(0, loadedSource.lastIndexOf("}"));
-            String[] sourceParts = loadedSource.split("\\s*void\\s*main\\s*\\(\\s*\\)\\s*\\{");
+            String[] sourceParts = loadedSource.split("\\s+void\\s+main\\s*\\(\\s*\\)\\s*\\{");
             if(sourceParts.length<2){
                 throw new IllegalArgumentException("Syntax error in "+ shaderPath +". Cannot find 'void main(){' in \n"+ loadedSource);
             }


### PR DESCRIPTION
We notice a vulnerability in ShaderGenerator.java class specifically in the appendNodeDeclarationAndMain method of the shader processing code due to the use of a regular expression with inefficient backtracking.
File Location: jme3-core/src/main/java/com/jme3/shader/ShaderGenerator.java

This vulnerability allows for ReDoS (Regular Expression Denial of Service) attacks, which was detected by SonarQube and can cause the application to become slow or unresponsive by exploiting inefficiencies in the regular expression matching process. When the \s* quantifier is used in multiple places, it can lead to exponential backtracking, especially with complex or large inputs, leading to high CPU usage.

Fix to issue https://github.com/rilling/jmonkeyengineFall2024/issues/130